### PR TITLE
Revert "Bump cryptography from 39.0.1 to 42.0.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nassl>=0.16.0,<0.17.0
 typing; python_version < '3.5'
 enum34; python_version < '3.4'
-cryptography==42.0.4
+cryptography==39.0.1
 tls-parser==1.0.0


### PR DESCRIPTION
Reverts ravigh/demo-lfs#6
Test